### PR TITLE
PlaySound () SoundKit IDs

### DIFF
--- a/MSBTOptions/MSBTOptionsControls.lua
+++ b/MSBTOptions/MSBTOptionsControls.lua
@@ -193,7 +193,7 @@ end
 local function Listbox_OnClickUp(this)
  local listbox = this:GetParent():GetParent();
  Listbox_ScrollUp(listbox);
- PlaySound("UChatScrollButton");
+ PlaySound("1115");
 end
 
 
@@ -203,7 +203,7 @@ end
 local function Listbox_OnClickDown(this)
  local listbox = this:GetParent():GetParent();
  Listbox_ScrollDown(listbox);
- PlaySound("UChatScrollButton");
+ PlaySound("1115");
 end
 
 
@@ -607,7 +607,7 @@ end
 -- ****************************************************************************
 local function Checkbox_OnClick(this)
  local isChecked = this:GetChecked() and true or false;
- if (isChecked) then PlaySound("igMainMenuOptionCheckBoxOn"); else PlaySound("igMainMenuOptionCheckBoxOff"); end
+ if (isChecked) then PlaySound("856"); else PlaySound("857"); end
 
  local checkbox = this:GetParent();
  if (checkbox.clickHandler) then checkbox:clickHandler(isChecked); end
@@ -776,7 +776,7 @@ end
 -- Called when the button is clicked.
 -- ****************************************************************************
 local function Button_OnClick(this)
- PlaySound("igMainMenuOptionCheckBoxOn");
+ PlaySound("856");
  if (this.clickHandler) then this:clickHandler(); end
 end
 

--- a/MSBTOptions/MSBTOptionsMain.lua
+++ b/MSBTOptions/MSBTOptionsMain.lua
@@ -140,7 +140,7 @@ end
 -- Called when the main options frame is hidden.
 -- ****************************************************************************
 local function OnHideMainFrame(this)
- PlaySound("gsTitleOptionExit")
+ PlaySound("799")
  -- Hide the registered popup frames.
  for frame in pairs(popupFrames) do
   frame:Hide()
@@ -166,7 +166,7 @@ local function CreateMainFrame()
  mainFrame:SetScript("OnHide", OnHideMainFrame)
 
  mainFrame:SetScript("OnShow", function(self)
-   PlaySound("igMainMenuOption")
+   PlaySound("852")
  end)
  mainFrame:SetScript("OnDragStart", function(self)
    self:StartMoving()

--- a/MSBTOptions/MSBTOptionsPopups.lua
+++ b/MSBTOptions/MSBTOptionsPopups.lua
@@ -107,7 +107,7 @@ end
 -- Called when a popup is hidden.
 -- ****************************************************************************
 local function OnHidePopup(this)
- PlaySound("gsTitleOptionExit")
+ PlaySound("799")
  if (this.hideHandler) then this.hideHandler() end
 end
 
@@ -128,7 +128,7 @@ local function CreatePopup()
  frame:SetScript("OnHide", OnHidePopup)
 
  frame:SetScript("OnShow", function(self)
-  PlaySound("igMainMenuOption")
+  PlaySound("852")
  end)
  frame:SetScript("OnDragStart", function(self)
   self:StartMoving()


### PR DESCRIPTION
Replaced all PlaySound() calls to their SoundKit ID equivalent to fix issue with the 7.3.0 patch API change.